### PR TITLE
Add results page, data packaging, etc.

### DIFF
--- a/Data/F-Capture.ps1
+++ b/Data/F-Capture.ps1
@@ -50,7 +50,7 @@ $MainForm.AutoScaleDimensions = New-Object System.Drawing.SizeF(6,13)
 $MainForm.AutoScaleMode       = [System.Windows.Forms.AutoScaleMode]::Dpi
 $MainForm.AutoScroll          = $true
 $MainForm.BackColor           = $MainFormBGColor
-$MainForm.ClientSize          = New-Object System.Drawing.Size(1146,663)
+$MainForm.ClientSize          = New-Object System.Drawing.Size(1146,690)
 $MainForm.Font                = 'Consolas,8.25'
 $MainForm.ForeColor           = $MainFormFGColor
 $MainForm.Icon                = $Icon
@@ -251,8 +251,7 @@ $DataRecoverySMItem.AutoToolTip = $true
 $DataRecoverySMItem.Name        = 'DataRecoverySMItem'
 $DataRecoverySMItem.Size        = New-Object System.Drawing.Size(180,22)
 $DataRecoverySMItem.Text        = 'Data Recovery'
-$DataRecoverySMItem.ToolTipText = "Not yet implemented"
-$DataRecoverySMItem.Enabled     = $false
+$DataRecoverySMItem.ToolTipText = "Starts TestDisk data recovery software"
 
 # Scan Registry Menu Item
 $ScanRegistrySMItem             = New-Object System.Windows.Forms.ToolStripMenuItem
@@ -504,11 +503,10 @@ $DataRecoveryBtn.BackColor = $ButtonBGColor
 $DataRecoveryBtn.ForeColor = $ButtonFGColor
 $DataRecoveryBtn.FlatStyle = [System.Windows.Forms.FlatStyle]::Popup
 $DataRecoveryBtn.Location  = New-Object System.Drawing.Point(755,325)
-$DataRecoveryBtn.Name      = 'VNCServerBtn'
+$DataRecoveryBtn.Name      = 'DataRecoveryBtn'
 $DataRecoveryBtn.Size      = New-Object System.Drawing.Size(112,38)
 $DataRecoveryBtn.TabIndex  = 49
 $DataRecoveryBtn.Text      = 'Data Recovery'
-$DataRecoveryBtn.Enabled   = $false # Not implemented yet, so disable it to communicate that
 
 # Scan Registry button config
 $RegistryScanBtn           = New-Object System.Windows.Forms.Button
@@ -1154,20 +1152,94 @@ $AdvOptionGrpBox.Controls.Add($MemoryImageCB)
 $AdvOptionGrpBox.Controls.Add($ActiveProcessesCB)
 $AdvOptionGrpBox.Controls.Add($SystemInfoCB)
 
-# ------------ Scanning Page Elements ------------
+# ------------ Results/Scanning Page Elements ------------
 
-# Progress bar
-# Timer; Count elapsed time; Estimate time left
+# Scanning label settings
+$ScanningLbl              = New-Object System.Windows.Forms.Label
+$ScanningLbl.Anchor       = [System.Windows.Forms.AnchorStyles]::None
+$ScanningLbl.BackColor    = $CheckmarkBGColor
+$ScanningLbl.Location     = New-Object System.Drawing.Point (320,0)
+$ScanningLbl.Font         = 'Consolas,12'
+$ScanningLbl.Name         = 'ScanningLbl'
+$ScanningLbl.Size         = New-Object System.Drawing.Size (504,39)
+$ScanningLbl.Text         = 'Scanning...'
+$ScanningLbl.TextAlign    = [System.Drawing.ContentAlignment]::MiddleCenter
 
-# ------------ Results Page Elements ------------
+# Results Textbox settings
+$ResultsTB                = New-Object System.Windows.Forms.TextBox
+$ResultsTB.Anchor         = [System.Windows.Forms.AnchorStyles]::None
+$ResultsTB.BackColor      = $ButtonBGColor
+$ResultsTB.ForeColor      = $ButtonFGColor
+$ResultsTB.Font           = 'Consolas,9.75'
+$ResultsTB.Location       = New-Object System.Drawing.Point(320,35)
+$ResultsTB.Name           = 'ResultsTB'
+$ResultsTB.Size           = New-Object System.Drawing.Size(504,334)
+$ResultsTB.TabStop        = $false
+$ResultsTB.Multiline      = $true
+$ResultsTB.ReadOnly       = $true
 
-# Panel or group with results textbox
-# Textbox has time elapsed, list of things done, successes/failures
+# Back to Main Menu Button settings
+$MainMenuBtn              = New-Object System.Windows.Forms.Button
+$MainMenuBtn.Anchor       = [System.Windows.Forms.AnchorStyles]::None
+$MainMenuBtn.BackColor    = $AdvBtnBGColor
+$MainMenuBtn.ForeColor    = 'White'
+$MainMenuBtn.Font         = 'Consolas,9.75'
+$MainMenuBtn.FlatStyle    = [System.Windows.Forms.FlatStyle]::Popup
+$MainMenuBtn.Location     = New-Object System.Drawing.Point(320,560)
+$MainMenuBtn.Name         = 'MainMenuBtn'
+$MainMenuBtn.Size         = New-Object System.Drawing.Size(122,39)
+$MainMenuBtn.TabIndex     = 2
+$MainMenuBtn.Text         = 'Main Menu'
+$MainMenuBtn.Visible      = $false
+
+# Open Output Folder Button settings
+$ViewOutputBtn            = New-Object System.Windows.Forms.Button
+$ViewOutputBtn.Anchor     = [System.Windows.Forms.AnchorStyles]::None
+$ViewOutputBtn.BackColor  = $AdvBtnBGColor
+$ViewOutputBtn.ForeColor  = 'White'
+$ViewOutputBtn.Font       = 'Consolas,9.75'
+$ViewOutputBtn.FlatStyle  = [System.Windows.Forms.FlatStyle]::Popup
+$ViewOutputBtn.Location   = New-Object System.Drawing.Point(511,560)
+$ViewOutputBtn.Name       = 'ViewOutputBtn'
+$ViewOutputBtn.Size       = New-Object System.Drawing.Size(122,39)
+$ViewOutputBtn.TabIndex   = 3
+$ViewOutputBtn.Text       = 'View Output'
+$ViewOutputBtn.Visible    = $false
+
+# Exit from Resutlts page Button settings
+$ExitResultsBtn           = New-Object System.Windows.Forms.Button
+$ExitResultsBtn.Anchor    = [System.Windows.Forms.AnchorStyles]::None
+$ExitResultsBtn.BackColor = $AdvBtnBGColor
+$ExitResultsBtn.ForeColor = 'White'
+$ExitResultsBtn.Font      = 'Consolas,9.75'
+$ExitResultsBtn.FlatStyle = [System.Windows.Forms.FlatStyle]::Popup
+$ExitResultsBtn.Location  = New-Object System.Drawing.Point(702,560)
+$ExitResultsBtn.Name      = 'ExitResultsBtn'
+$ExitResultsBtn.Size      = New-Object System.Drawing.Size(122,39)
+$ExitResultsBtn.TabIndex  = 4
+$ExitResultsBtn.Text      = 'Exit'
+$ExitResultsBtn.Visible   = $false
+
+# Results Page Panel
+$ResultsPanel             = New-Object System.Windows.Forms.Panel
+$ResultsPanel.Anchor      = ([System.Windows.Forms.AnchorStyles][System.Windows.Forms.AnchorStyles]::Left -bor [System.Windows.Forms.AnchorStyles]::Right)
+$ResultsPanel.BackColor   = $BannerBGColor
+$ResultsPanel.Location    = New-Object System.Drawing.Point(0,150)
+$ResultsPanel.MaximumSize = New-Object System.Drawing.Size(10000,400)
+$ResultsPanel.Name        = 'ResultsPanel'
+$ResultsPanel.Size        = New-Object System.Drawing.Size(1146,400)
+$ResultsPanel.Visible     = $false
+$ResultsPanel.Controls.Add($ResultsTB)
+$ResultsPanel.Controls.Add($ScanningLbl)
 
 # -----------------------------------------------
 
 # Add buttons to the main form's list of elements
 
+$MainForm.Controls.Add($ExitResultsBtn)
+$MainForm.Controls.Add($ViewOutputBtn)
+$MainForm.Controls.Add($MainMenuBtn)
+$MainForm.Controls.Add($ResultsPanel)
 $MainForm.Controls.Add($GoButton)
 $MainForm.Controls.Add($FCapTitle)
 $MainForm.Controls.Add($OutDirTextBoxLbl)
@@ -1192,7 +1264,7 @@ $Tooltip.SetToolTip( $ZipOutputRBtn,      "Save all program output in a single .
 $Tooltip.SetToolTip( $VHDXOutputRBtn,     "Save all program output to a single .vhdx file")
 $Tooltip.SetToolTip( $PuTTYBtn,           "Open PuTTY, a free and open-source terminal emulator,`nserial console and network file transfer application")
 $Tooltip.SetToolTip( $VNCServerBtn,       "Not yet implemented")
-$Tooltip.SetToolTip( $DataRecoveryBtn,    "Not yet implemented")
+$Tooltip.SetToolTip( $DataRecoveryBtn,    "Starts TestDisk data recovery software")
 $Tooltip.SetToolTip( $RegistryScanBtn,    "Open RegScanner, a small utility that allows you to scan the Registry`nfor a particular string and then view or export the matches to a .reg file")
 $Tooltip.SetToolTip( $SystemInfoCB,       "Record a detailed overview of the system specifications, etc.")
 $Tooltip.SetToolTip( $ActiveProcessesCB,  "Record a list of the currently active processes")
@@ -1268,6 +1340,11 @@ $VNCServerBtn.Add_Click({ Start-VNC-Server })
 $DataRecoveryBtn.Add_Click({ Start-Recovery-Tool })
 $RegistryScanBtn.Add_Click({ Scan-Registry })
 $CheckUncheckAllCB.Add_CheckedChanged({ Toggle-All-Checkboxes })
+
+# Results Page Events
+$MainMenuBtn.Add_Click({ Close-Results-Page })
+$ViewOutputBtn.Add_Click({ Invoke-Item $global:OUTPUT_DIR })
+$ExitResultsBtn.Add_Click({ $MainForm.Close() })
 
 Register-ObjectEvent -InputObject $MainForm -EventName FormClosing -Action { Store-Main-State } | Out-Null
 

--- a/Data/F-Capture.ps1
+++ b/Data/F-Capture.ps1
@@ -1168,6 +1168,7 @@ $ScanningLbl.TextAlign    = [System.Drawing.ContentAlignment]::MiddleCenter
 # Results Textbox settings
 $ResultsTB                = New-Object System.Windows.Forms.TextBox
 $ResultsTB.Anchor         = [System.Windows.Forms.AnchorStyles]::None
+$ResultsTB.ScrollBars     = [System.Windows.Forms.ScrollBars]::Vertical
 $ResultsTB.BackColor      = $ButtonBGColor
 $ResultsTB.ForeColor      = $ButtonFGColor
 $ResultsTB.Font           = 'Consolas,9.75'

--- a/Data/Resources/Make_FCAP_exe.cs
+++ b/Data/Resources/Make_FCAP_exe.cs
@@ -1,9 +1,10 @@
 // Credit: https://stackoverflow.com/a/54706445
 
 // To Create .exe from .bat file:
+// FIRST: Move this script to the ROOT of the FCapture hierarchy (as in, where the .exe file would reasonably be expected to go)
 // In command prompt, navigate to the FCapture root folder on your computer.
 // Enter the following command (may have to alter for your machine):
-// C:\WINDOWS\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:winexe /win32icon:Data\Resources\FCAP.ico F-Capture.cs
+// C:\WINDOWS\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:winexe /win32icon:Data\Resources\FCAP.ico Make_FCAP_exe.cs
 
 using System;
 using System.Diagnostics;

--- a/Data/Scripts/Jump-List.ps1
+++ b/Data/Scripts/Jump-List.ps1
@@ -1,23 +1,25 @@
 function Jump-List
 {
-    $jumpListPaths = Resolve-Path "$env:HOMEDRIVE\Users\*\AppData\Roaming\Microsoft\Windows\Recent" | Select -ExpandProperty Path
-    
-    ForEach($jumpListPath in $jumpListPaths)
+    # Get a list of names of users that actually have jump lists
+    $users       = Split-Path -Path (Resolve-Path "$env:HOMEDRIVE\Users\*" | Select -ExpandProperty Path) -Leaf
+    $usefulUsers = $users | Where {Test-Path "$env:HOMEDRIVE\Users\$_\AppData\Roaming\Microsoft\Windows\Recent"}
+
+    # Copy the jump lists of each user to the output directory
+    ForEach($user in $usefulUsers)
     {
-        # Make a path to save output
-        # Maintain/copy hierarchy because it's simple and straight-forward
-        $unqualifiedJLPath = Split-Path -Path (Split-Path -Path $jumpListPath -NoQualifier) -Parent
-        $completeOutPath   = "$global:OUTPUT_DIR\JumpLists$unqualifiedJLPath"
+        # Make a path to the jump list folder for this user and to the output folder we will copy it to
+        $JLInPath  = "$env:HOMEDRIVE\Users\$user\AppData\Roaming\Microsoft\Windows\Recent"
+        $JLOutPath = "$global:OUTPUT_DIR\JumpLists\Users\$user"
 
         try
         { 
-            New-Item -Path $completeOutPath -ItemType Directory
-            Copy-Item $jumpListPath -Destination $completeOutPath -Recurse
-            Search-And-Add-Log-Entry $SUCCESS_LOG "Copied Jump List directories/files at $jumpListPath"
+            New-Item -Path $JLOutPath -ItemType Directory
+            Copy-Item $JLInPath -Destination $JLOutPath -Recurse
+            Search-And-Add-Log-Entry $SUCCESS_LOG "Copied Jump List directories/files at $JLInPath"
         }
         catch
         { 
-            Search-And-Add-Log-Entry $FAIL_LOG "Failed to copy Jump List directories/files at $jumpListPath"
+            Search-And-Add-Log-Entry $FAIL_LOG "Failed to copy Jump List directories/files at $JLInPath"
         }
     }
 }

--- a/Data/Scripts/Menu-Transitions.ps1
+++ b/Data/Scripts/Menu-Transitions.ps1
@@ -46,3 +46,37 @@ function Close-Advanced-Menu()
 	$AdvancedBtn.Show()
     $BgPanel.Show()
 }
+
+function Open-Results-Page()
+{
+    # Hide Main Menu UI elements
+	$GoButton.Hide()
+    $OutDirTextBoxLbl.Hide()
+	$OutDirBtn.Hide()
+	$OutDirTextBox.Hide()
+	$AdvancedBtn.Hide()
+    $BgPanel.Hide()
+
+    # Show Results Page UI Elements
+    $ResultsPanel.Show()
+    $MainMenuBtn.Show()
+    $ViewOutputBtn.Show()
+    $ExitResultsBtn.Show()
+}
+
+function Close-Results-Page()
+{
+    # Hide Results Page UI Elements
+    $ResultsPanel.Hide()
+    $MainMenuBtn.Hide()
+    $ViewOutputBtn.Hide()
+    $ExitResultsBtn.Hide()
+    
+    # Show Main Menu UI elements
+	$GoButton.Show()
+    $OutDirTextBoxLbl.Show()
+	$OutDirBtn.Show()
+	$OutDirTextBox.Show()
+	$AdvancedBtn.Show()
+    $BgPanel.Show()
+}

--- a/Data/Scripts/OneForAll.ps1
+++ b/Data/Scripts/OneForAll.ps1
@@ -1,65 +1,117 @@
 function OneForAll
 {
-    # Fail if user hasn't picked an output directory and the f-capture root dir is not on removable drive
-    if(("" -eq $OutDirTextBox.text) -and (!(Assert-Path-Is-On-Removable-Device "$PSScriptRoot"))){ return }
+    # Fail if user hasn't picked an usable output directory
+    if("" -eq $OutDirTextBox.text)
+    {
+        # If the script root is on a removable drive (or if dev mode is on),
+        # make a new folder in the script root called DefaultOutput and set OUPUT_DIR to that
+        if((Assert-Path-Is-On-Removable-Device "$PSScriptRoot") -or ($global:DEV_MODE))
+        {
+            New-Item -Name "DefaultOutput" -Path "$PSScriptRoot\.." -ItemType Directory -ErrorAction SilentlyContinue
+            if(Test-Path "$PSScriptRoot\..\DefaultOutput") { $global:OUTPUT_DIR = "$PSScriptRoot\..\DefaultOutput" }
+            else { return }
+        }
+        else # Bring up a message box to tell user to choose a usable drive and return
+        {
+            Add-Type -AssemblyName PresentationFramework
+            [System.Windows.MessageBox]::Show('You must choose an output directory that is not on the local machine.','Output Directory Error','OK','Error')
+            return
+        }
+    }
+
+    # Open results page
+    Open-Results-Page
 
     # Disable Buttons
-    $GoButton.Enabled    = $false
-    $AdvancedBtn.Enabled = $false
-    $GoSMItem.Enabled    = $false
+    $GoSMItem.Enabled       = $false
+    $MainMenuBtn.Enabled    = $false
+    $ViewOutputBtn.Enabled  = $false
+    $ExitResultsBtn.Enabled = $false
+
+    # Inform user that scan has started
+    $ScanningLbl.Text = 'Scanning...'
+    $ResultsTB.Text   = "Scan started..."
+    $ResultsTB.AppendText("`r`n`r`n")
+
+    # Log the time that the scan started
+    $startTime = Get-Date
 
     # Start packet capture
-    if($PacketCaptureCB.Checked){ Packet-Capture-Start }
+    if($PacketCaptureCB.Checked){ Update-TB("Start packet capture"); Packet-Capture-Start; Update-TB }
 
     # Do everything else
-    if($NetworkShareInfoCB.Checked){ Network-Share-Info }
-    if($NetworkInterfacesCB.Checked){ Network-Interfaces }
-    if($FileSystemInfoCB.Checked){ Filesystem-Info }
-    if($AutoRunItemsCB.Checked){ AutoRun-Items }
-    if($UserAssistInfoCB.Checked){ UserAssist }
-    if($NetworkProfilesCB.Checked){ Net-Connection-Profile }
-    if($UserAccountsCB.Checked){ User-Accounts }
-    if($TimezoneInfoCB.Checked){ Timezone-Info }
-    if($WindowsServicesCB.Checked){ Windows-Services }
-    if($SRUMInfoCB.Checked){ SRUM }
-    if($RestorePointsCB.Checked){ System-Restore-Points }
-    if($ShimCacheCB.Checked){ ShimCache }
-    if($ShellbagsCB.Checked){ Shellbags }
-    if($ScheduledTasksCB.Checked){ Scheduled-Tasks }
-    if($RDPCacheCB.Checked){ Remote-Desktop }
-    if($RecycleBinCB.Checked){ Recycle-Bin }
-    if($PrefetchFilesCB.Checked){ Prefetch }
-    if($MRUListsCB.Checked){ MRU }
-    if($LNKFilesCB.Checked){ LNK }
-    if($DLLsCB.Checked){ DLL }
-    if($KeywordSearchesCB.Checked){ KeyWord-Search }
-    if($JumpListsCB.Checked){ Jump-List }
-    if($InstalledProgramsCB.Checked){ Installed-Programs }
-    if($FileAssociationsCB.Checked){ File-Associations }
-    if($StartupProgramsCB.Checked){ Startup-Programs }
-    if($AmCacheCB.Checked){ AmCache }
-    if($MUICacheCB.Checked){ MUICache }
-    if($EventLogsCB.Checked){ Event-Logs }
-    if($RegistryCB.Checked){ Record-Registry }
-    if($ImageScanCB.Checked){ Image-Scan }
-    if($PeripheralDevicesCB.Checked){ Peripheral-Devices }
-    if($BrowserHistoryCB.Checked){ Browser-History }
-    if($BrowserCookiesCB.Checked){ Browser-Cookies }
-    if($ScreenshotsCB.Checked){ Screenshot }
+    if($NetworkShareInfoCB.Checked){ Update-TB("Network Share Info"); Network-Share-Info; Update-TB }
+    if($NetworkInterfacesCB.Checked){ Update-TB("Network Interfaces"); Network-Interfaces; Update-TB }
+    if($FileSystemInfoCB.Checked){ Update-TB("FileSystem Info"); Filesystem-Info; Update-TB }
+    if($AutoRunItemsCB.Checked){ Update-TB("AutoRun Items"); AutoRun-Items; Update-TB }
+    if($UserAssistInfoCB.Checked){ Update-TB("UserAssist Info"); UserAssist; Update-TB }
+    if($NetworkProfilesCB.Checked){ Update-TB("Network Profiles"); Net-Connection-Profile; Update-TB }
+    if($UserAccountsCB.Checked){ Update-TB("User Accounts"); User-Accounts; Update-TB }
+    if($TimezoneInfoCB.Checked){ Update-TB("Timezone Info"); Timezone-Info; Update-TB }
+    if($WindowsServicesCB.Checked){ Update-TB("Windows Services"); Windows-Services; Update-TB }
+    if($SRUMInfoCB.Checked){ Update-TB("SRUM Info"); SRUM; Update-TB }
+    if($RestorePointsCB.Checked){ Update-TB("Restore Points"); System-Restore-Points; Update-TB }
+    if($ShimCacheCB.Checked){ Update-TB("ShimCache"); ShimCache; Update-TB }
+    if($ShellbagsCB.Checked){ Update-TB("Shellbags"); Shellbags; Update-TB }
+    if($ScheduledTasksCB.Checked){ Update-TB("Scheduled Tasks"); Scheduled-Tasks; Update-TB }
+    if($RDPCacheCB.Checked){ Update-TB("RDP Cache"); Remote-Desktop; Update-TB }
+    if($RecycleBinCB.Checked){ Update-TB("Recycle Bin"); Recycle-Bin; Update-TB }
+    if($PrefetchFilesCB.Checked){ Update-TB("Prefetch Files"); Prefetch; Update-TB }
+    if($MRUListsCB.Checked){ Update-TB("MRU Lists"); MRU; Update-TB }
+    if($LNKFilesCB.Checked){ Update-TB("LNK Files"); LNK; Update-TB }
+    if($DLLsCB.Checked){ Update-TB("DLLs"); DLL; Update-TB }
+    if($KeywordSearchesCB.Checked){ Update-TB("Keyword Searches"); KeyWord-Search; Update-TB }
+    if($JumpListsCB.Checked){ Update-TB("Jump Lists"); Jump-List; Update-TB }
+    if($InstalledProgramsCB.Checked){ Update-TB("Installed Programs"); Installed-Programs; Update-TB }
+    if($FileAssociationsCB.Checked){ Update-TB("File Associations"); File-Associations; Update-TB }
+    if($StartupProgramsCB.Checked){ Update-TB("Startup Programs"); Startup-Programs; Update-TB }
+    if($AmCacheCB.Checked){ Update-TB("AmCache"); AmCache; Update-TB }
+    if($MUICacheCB.Checked){ Update-TB("MUICache"); MUICache; Update-TB }
+    if($EventLogsCB.Checked){ Update-TB("Event Logs"); Event-Logs; Update-TB }
+    if($RegistryCB.Checked){ Update-TB("Registry"); Record-Registry; Update-TB }
+    if($ImageScanCB.Checked){ Update-TB("Image Scan"); Image-Scan; Update-TB }
+    if($PeripheralDevicesCB.Checked){ Update-TB("Peripheral Devices"); Peripheral-Devices; Update-TB }
+    if($BrowserHistoryCB.Checked){ Update-TB("Browser History"); Browser-History; Update-TB }
+    if($BrowserCookiesCB.Checked){ Update-TB("Browser Cookies"); Browser-Cookies; Update-TB }
+    if($ScreenshotsCB.Checked){ Update-TB("Screenshots"); Screenshot; Update-TB }
     if($MemoryImageCB.Checked -or $SwapFilesCB.Checked){
-		if($SwapFilesCB.Checked){ Swap-Files }
-		else{ PhysicalMemory-Image }}
-    if($ActiveProcessesCB.Checked){ Active-Processes }
-    if($SystemInfoCB.Checked){ System-Info }
+		if($SwapFilesCB.Checked){ Update-TB("Swap Files"); Swap-Files; Update-TB }
+		else{ Update-TB("Physical Memory Imaging"); PhysicalMemory-Image; Update-TB }}
+    if($ActiveProcessesCB.Checked){ Update-TB("Active Processes"); Active-Processes; Update-TB }
+    if($SystemInfoCB.Checked){ Update-TB("System Info"); System-Info; Update-TB }
 
     # Image drives that the user requested, if any
-    Disk-Image
+    Update-TB("Image disks"); Disk-Image; Update-TB
 
     # End packet capture
-    if($PacketCaptureCB.Checked){ Packet-Capture-Stop }
+    if($PacketCaptureCB.Checked){ Update-TB("Stop packet capture"); Packet-Capture-Stop; Update-TB }
+
+    # Package output data into .zip or .vhdx
+    Update-TB("Package data"); Package-Output-Data; Update-TB
+
+    # Calculate the elapsed time since the scan started, then diplay it in results textbox
+    $elapsedTime = "{0:HH:mm:ss}" -f ([datetime]($(Get-Date) - $startTime).Ticks)
+    $ResultsTB.AppendText("`r`nElapsed time: $elapsedTime`r`n")
+
+    # Inform user that scan is complete
+    $ScanningLbl.Text = 'Scan Complete'
+    $ResultsTB.AppendText("`r`nFinished")
 
     # Re-enable buttons
-    $GoButton.Enabled    = $true
-    $AdvancedBtn.Enabled = $true
-    $GoSMItem.Enabled    = $true
+    $GoSMItem.Enabled       = $true
+    $MainMenuBtn.Enabled    = $true
+    $ViewOutputBtn.Enabled  = $true
+    $ExitResultsBtn.Enabled = $true
+}
+
+function Update-TB([string]$action)
+{
+    if($action -ne "") # "" denotes the action is finished
+    {
+        $ResultsTB.AppendText("$action...")
+    }
+    else # Otherwise the action is starting
+    {
+        $ResultsTB.AppendText("Done`r`n")
+    }
 }

--- a/Data/Scripts/OutputLocation.ps1
+++ b/Data/Scripts/OutputLocation.ps1
@@ -25,10 +25,14 @@ function Output-Location
 	#Make sure the selected path is useable (or dev mode is on)
 	if((Assert-Path-Is-On-Removable-Device $selectedOutputPath) -or ($global:DEV_MODE))
 	{
-        # Set global directory location for other scripts to use
-        $global:OUTPUT_DIR = $selectedOutputPath
+        # Create a new folder in the chosen folder to hold output files
+        # This avoids complex issues when archiving files later on
+        New-Item -Name "F_Capture" -Path $selectedOutputPath -ItemType Directory -ErrorAction SilentlyContinue
 
-        # Let user know if they are in dev mode, and that they selected a local machine folder
+        # Set global directory location for other scripts to use
+        $global:OUTPUT_DIR = "$selectedOutputPath\F_Capture"
+
+        # Let user know if they are in dev mode, if they are
 		if($global:DEV_MODE){ Write-Host "(DEV MODE) Successfully selected output destination" }
         else{ Write-Host "Successfully selected removable output destination" }
 		
@@ -40,6 +44,8 @@ function Output-Location
 	}
 	else
     {
+        Add-Type -AssemblyName PresentationFramework
+        [System.Windows.MessageBox]::Show('You must choose an output directory that is not on the local machine.','Output Directory Error','OK','Error')
         Write-Host "Selected output destination was on local machine"
 		Add-Log-Entry $FAIL_LOG "Failed to change output directory"
 	}

--- a/Data/Scripts/Package-Output.ps1
+++ b/Data/Scripts/Package-Output.ps1
@@ -1,0 +1,91 @@
+﻿<#
+    This function takes all of the output folders and files that were created
+    during the operation of the program and compresses them into a zip archive
+    or puts them into a vhdx file, depending on the user's decision in the
+    advanced menu.
+    The way this is done is fairly convoluted, but it works.
+
+    ***WARNINGS***
+    - The $outputFilename is too long for Fat32, and will only work for Ntfs;
+    If the filesystem is ever changed, it's highly likely that the $outputFilename
+    will need to be changed/shortened.
+    - For some reason, folders with many subfolders (like Jump Lists) occasionally
+    won't end up in the archive and instead remain outside of it. Not sure why.
+#>
+function Package-Output-Data
+{
+    Add-Type -AssemblyName System.IO.Compression.Filesystem # Needed to create .zip archive
+    $ErrorActionPreference = 'silentlycontinue' # Don't print errors to the console if encountered
+    $timestamp      = Get-Date -Format "HHmmss_ddMMyyyy" # Differentiates each output file by date/time created
+    $outputFilename = "FCAP_OUTPUT_$timestamp" # The actual filename of the .zip or .vhdx file
+
+    if($ZipOutputRBtn.Checked) # Output the collected data as a .zip file
+    {
+        # Temporarily create a folder containing the folder that will be archived
+        New-Item -Name "FCAP_OUTPUT\FCAP_OUTPUT" -Path "$PSScriptRoot\.." -ItemType Directory
+
+        # Move all of the output files\folders to the inner folder, skipping any output files from previous scans
+        Move-Item "$global:OUTPUT_DIR\*" -Destination "$PSScriptRoot\..\FCAP_OUTPUT\FCAP_OUTPUT" -Force -Exclude "FCAP_OUTPUT*"
+
+        # Zip the inner folder, name it with timestamp, then place it in the output directory
+        [IO.Compression.Zipfile]::CreateFromDirectory("$PSScriptRoot\..\FCAP_OUTPUT","$global:OUTPUT_DIR\$outputFilename.zip")
+        Remove-Item "$PSScriptRoot\..\FCAP_OUTPUT" -Recurse -Force # Remove the temporary folder that was just archived
+    }
+    else # Output the collected data as a .vhdx file
+    {
+        # Estimate the size of the virtual HD, rounding up 1Gb for some breathing room
+        $outFolderSize = [math]::Round((Get-ChildItem $global:OUTPUT_DIR | Measure-Object -Property Length -Sum).Sum / 1Mb) + 1024
+        $qualifiedPath = Resolve-Path -Path "$PSScriptRoot\.."
+        
+        # Create a script to be used by diskpart, which creates, mounts, formats, and sets up the VHD
+        $diskPartScript =
+@"
+create vdisk file="$qualifiedPath\$outputFilename.vhdx" maximum=$outFolderSize type=expandable
+select vdisk file="$qualifiedPath\$outputFilename.vhdx"
+attach vdisk
+create partition primary
+format fs=NTFS label="$outputFilename" quick
+assign
+"@
+        # Create DPScript.txt because diskpart needs an actual text file to use as a script
+        New-Item -Name "DPScript.txt" -Path "$PSScriptRoot\.." -ItemType File -Value $diskPartScript
+
+        # Run diskpart with DPScript.txt, catch the output in $dpOutput to stop it printing to console
+        $dpOutput = (Diskpart /s "$PSScriptRoot\..\DPScript.txt")
+
+        # Find the drive letter of the newly created and mounted VHD, append a ':' to it
+        $vhdx = (Get-Volume -FriendlyName "$outputFilename").DriveLetter + ":"
+
+        # Create a folder to hold the F-Capture output data in the VHD
+        New-Item -Name "FCAP_OUTPUT" -Path "$vhdx" -ItemType Directory
+
+        # Move all of the output data to the newly created folder on the VHD, skipping any output files from previous scans
+        Move-Item "$global:OUTPUT_DIR\*" -Destination "$vhdx\FCAP_OUTPUT" -Force -Exclude "FCAP_OUTPUT*"
+
+        # Create a new script to be used by diskpart to unmount the VHD
+        $diskPartScript =
+@"
+select vdisk file="$qualifiedPath\$outputFilename.vhdx"
+detach vdisk
+"@
+        # Create text file containing script so diskpart can use it
+        Set-Content -Path "$PSScriptRoot\..\DPScript.txt" -Value $diskPartScript
+        $dpOutput = (Diskpart /s "$PSScriptRoot\..\DPScript.txt") # Run diskpart with DPScript.txt
+        Remove-Item "$PSScriptRoot\..\DPScript.txt" # Remove DPScript.txt, as it isn't needed anymore
+
+        # Move the (now unmounted) VHDX file to the output folder
+        Move-Item -Path "$PSScriptRoot\..\$outputFilename.vhdx" -Destination "$global:OUTPUT_DIR\$outputFilename.vhdx"
+    }
+    # Test whether a file with the expected name was created, consider its existence a sign of success
+    # Add log entries accordingly and return true or false to signify success or failure to calling function
+    if(Test-Path "$global:OUTPUT_DIR\$outputFilename.*")
+    {
+        Search-And-Add-Log-Entry $SUCCESS_LOG ("Created $outputFilename output file successfully")
+        return $true
+    }
+    else
+    {
+        Search-And-Add-Log-Entry $FAIL_LOG ("Failed to create $outputFilename output file")
+        return $false
+    }
+}

--- a/Data/Scripts/User-Profiles.ps1
+++ b/Data/Scripts/User-Profiles.ps1
@@ -6,7 +6,7 @@ function Save-User-Profile {
     }
     $State = [ordered]@{}
     Update-State $MainForm $State ""
-    Save-Recoverable $State "$global:OUTPUT_DIR\Profiles\$Name.xml"
+    Save-Recoverable $State "$PSScriptRoot\..\Profiles\$Name.xml"
 }
 
 function Load-User-Profile {
@@ -18,7 +18,7 @@ function Load-User-Profile {
     }
 
     # Check if any profiles exist in directory
-    $ProfileDir = Get-ChildItem -Path "$global:OUTPUT_DIR\Profiles\"
+    $ProfileDir = Get-ChildItem -Path "$PSScriptRoot\..\Profiles\"
     if(!$ProfileDir) {
         Write-Host "Profile not found."
         return
@@ -33,7 +33,7 @@ function Load-User-Profile {
     # Check list of profiles names for a match
     if($NameList -match $Name) { 
         $State = [ordered]@{}
-        Load-Recoverable $State "$global:OUTPUT_DIR\Profiles\$Name.xml"
+        Load-Recoverable $State "$PSScriptRoot\..\Profiles\$Name.xml"
         Set-State $MainForm $State
     } else {
         Write-Host "Profile not found."
@@ -43,7 +43,7 @@ function Load-User-Profile {
 
 function Update-DD {
     $ProfileDropdown.Items.Clear()
-    $ProfileDir = Get-ChildItem -Path "$global:OUTPUT_DIR\Profiles\"
+    $ProfileDir = Get-ChildItem -Path "$PSScriptRoot\..\Profiles\"
     if(!$ProfileDir) {
         return
     }

--- a/Data/Scripts/~IMPORTS.ps1
+++ b/Data/Scripts/~IMPORTS.ps1
@@ -50,3 +50,4 @@
 . "$PSScriptRoot\Data-Recovery.ps1"
 . "$PSScriptRoot\VNC-Server.ps1"
 . "$PSScriptRoot\MUICache.ps1"
+. "$PSScriptRoot\Package-Output.ps1"


### PR DESCRIPTION
- Added a results page that writes out the current process as it's being done, then shows the elapsed time of the scan and finishes.
- The results page has 3 buttons that allow the user to go back to the main menu, view the output file in the explorer, or exit the program. These buttons are disabled while a scan is running.
- Added the Package-Output.ps1 script, which allows the output files/folders to be packaged up into either a .zip or .vhdx depending on the user selection.
- Changed the User-Profiles.ps1 script because it was saving/loading profiles from the output folder, which was causing errors when the output folder was anything expect the default location.
- Updated the Jump-Lists.ps1 script to create a less verbose folder hierarchy.
- Updated ~IMPORTS.ps1 to include the new script I added.
- Updated output location to create an output folder in the chosen location to save everything to, and to bring up a messsage box to instruct the user if they try to use a local output location.
- Added menu transitions for the results page to Menu-Transitions.ps1.
-  Updated Data recovery labels and such in order to avoid a conflict with the last merge.