### PR TITLE
Temp bugfix Recycle-Bin, bugfix with output packaging and record-user-actions

### DIFF
--- a/Data/Scripts/Package-Output.ps1
+++ b/Data/Scripts/Package-Output.ps1
@@ -24,8 +24,8 @@ function Package-Output-Data
         # Temporarily create a folder containing the folder that will be archived
         New-Item -Name "FCAP_OUTPUT\FCAP_OUTPUT" -Path "$PSScriptRoot\.." -ItemType Directory
 
-        # Move all of the output files\folders to the inner folder, skipping any output files from previous scans
-        Move-Item "$global:OUTPUT_DIR\*" -Destination "$PSScriptRoot\..\FCAP_OUTPUT\FCAP_OUTPUT" -Force -Exclude "FCAP_OUTPUT*"
+        # Move all of the output files\folders to the inner folder, skipping any output files from previous scans and the Record folder
+        Move-Item "$global:OUTPUT_DIR\*" -Destination "$PSScriptRoot\..\FCAP_OUTPUT\FCAP_OUTPUT" -Force -Exclude @("FCAP_OUTPUT*","Record")
 
         # Zip the inner folder, name it with timestamp, then place it in the output directory
         [IO.Compression.Zipfile]::CreateFromDirectory("$PSScriptRoot\..\FCAP_OUTPUT","$global:OUTPUT_DIR\$outputFilename.zip")
@@ -59,8 +59,8 @@ assign
         # Create a folder to hold the F-Capture output data in the VHD
         New-Item -Name "FCAP_OUTPUT" -Path "$vhdx" -ItemType Directory
 
-        # Move all of the output data to the newly created folder on the VHD, skipping any output files from previous scans
-        Move-Item "$global:OUTPUT_DIR\*" -Destination "$vhdx\FCAP_OUTPUT" -Force -Exclude "FCAP_OUTPUT*"
+        # Move all of the output data to the newly created folder on the VHD, skipping any output files from previous scans and the Record folder
+        Move-Item "$global:OUTPUT_DIR\*" -Destination "$vhdx\FCAP_OUTPUT" -Force -Exclude @("FCAP_OUTPUT*","Record")
 
         # Create a new script to be used by diskpart to unmount the VHD
         $diskPartScript =

--- a/Data/Scripts/Recycle-Bin.ps1
+++ b/Data/Scripts/Recycle-Bin.ps1
@@ -1,5 +1,14 @@
 
 function Get-Recycle-Bin {
+#  ---Temporary function---
+
+    # This is a temporary function for use until the original function is bugfixed
+    $RBPath  = "$env:HOMEDRIVE\`$Recycle.Bin"
+    $outPath = "$global:OUTPUT_DIR\RecycleBinFiles"
+
+    Copy-Item -Path $RBPath -Destination $outPath -Recurse -Force #-ErrorAction SilentlyContinue
+
+<# ---Original function---
 
  [CmdletBinding()]
     param ( [string]$path, [string]$destination)
@@ -27,6 +36,6 @@ function Get-Recycle-Bin {
      Write-Information -MessageData "File copied successfully" -InformationAction Continue
    }
  }
-} 
-# This line is outside of the function so it's being called immediately upon starting the program and causing errors
-#Get-Recycle-Bin 'C:\$Recycle.Bin\*' "$global:OUTPUT_DIR\RecycleBinFiles" | Out-File "$global:OUTPUT_DIR\Recyclebincontents.txt"
+ #>
+}
+# Get-Recycle-Bin 'C:\$Recycle.Bin\*' "$global:OUTPUT_DIR\RecycleBinFiles" | Out-File "$global:OUTPUT_DIR\RecycleBinContents.txt"

--- a/Data/Scripts/Recycle-Bin.ps1
+++ b/Data/Scripts/Recycle-Bin.ps1
@@ -6,7 +6,7 @@ function Get-Recycle-Bin {
     $RBPath  = "$env:HOMEDRIVE\`$Recycle.Bin"
     $outPath = "$global:OUTPUT_DIR\RecycleBinFiles"
 
-    Copy-Item -Path $RBPath -Destination $outPath -Recurse -Force #-ErrorAction SilentlyContinue
+    Copy-Item -Path $RBPath -Destination $outPath -Recurse -Force -ErrorAction SilentlyContinue
 
 <# ---Original function---
 
@@ -38,4 +38,5 @@ function Get-Recycle-Bin {
  }
  #>
 }
+# This line is outside of the function so it's being called immediately upon starting the program and causing errors
 # Get-Recycle-Bin 'C:\$Recycle.Bin\*' "$global:OUTPUT_DIR\RecycleBinFiles" | Out-File "$global:OUTPUT_DIR\RecycleBinContents.txt"


### PR DESCRIPTION
- The Get-Recycle-Bin function was causing the program to essentially crash, so I added a much more naive version of Kelsey's function that seems to do the same thing with less checks and error handling. The intention is for this to be in place temporarily until Kelsey can work on fixing the original function.
- Also, made it so that the output packaging process doesn't touch the Record folder, if present, to avoid packaging up the output from Record-User-Actions if the program is ran more than once with the same output folder